### PR TITLE
Topo2 is discontinued. Replaced by topo4. http://status.kartverket.no…

### DIFF
--- a/L.TileLayer.Kartverket.js
+++ b/L.TileLayer.Kartverket.js
@@ -9,8 +9,8 @@
 
         layers: [
             'matrikkel_bakgrunn',
-            'topo2',
-            'topo2graatone',
+            'topo4',
+            'topo4graatone',
             'europa',
             'toporaster2',
             'sjo_hovedkart2',
@@ -22,8 +22,8 @@
 
         layerNames: [
             'Matrikkel bakgrunn',
-            'Topografisk norgeskart 2',
-            'Topografisk norgeskart 2 gråtone',
+            'Topografisk norgeskart 4',
+            'Topografisk norgeskart 4 gråtone',
             'Europakart',
             'Topografisk norgeskart, raster 2',
             'Sjøkart hovedkartserien 2',


### PR DESCRIPTION
http://status.kartverket.no/2018/04/05/topo2-og-topo2graatone-cache-tjeneter/

I haven't checked the entire list of base layers.