### PR TITLE
Fix matrikkel bakgrunn layer name

### DIFF
--- a/L.TileLayer.Kartverket.js
+++ b/L.TileLayer.Kartverket.js
@@ -24,7 +24,7 @@
         },
 
         layers: [
-            'matrikkel_bakgrunn',
+            'matrikkel_bakgrunn2',
             'topo4',
             'topo4graatone',
             'europa',


### PR DESCRIPTION
According to this [XML document](https://opencache.statkart.no/gatekeeper/gk/gk.open?Version=1.0.0&service=wms&request=getcapabilities) (linked from [here](https://www.kartverket.no/data/API-er-og-tjenester/)) the `matrikkel_bakgrunn` layer has been renamed to `matrikkel_bakgrunn2`.